### PR TITLE
Use the `main` version for `actions/checkout`

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,6 +1,4 @@
-
 name: luacheck
-
 on: [push, pull_request]
 
 jobs:
@@ -9,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@main
     - name: apt
       run: sudo apt-get install -y luarocks
     - name: luacheck install


### PR DESCRIPTION
Things added/changed:

- Use the `main` version for `actions/checkout`.
